### PR TITLE
Add gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Virtual environment
+venv/
+
+# Environment variables
+.env
+
+# MacOS metadata
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore Python caches and virtual environment directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6852899b495c8330b2191bee6ce0921e